### PR TITLE
Move ZMQ and SQLite into dpipes subpackages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,12 @@ bin/tarp: $(cmds) $(datapipes)
 	bin/tarp -h
 
 test:
-	cd datapipes && go test -v
+	cd dpipes && go test -v ./...
 
 dtest:
-	cd datapipes && debug=stdout go test -v | tee ../test.log
+	cd dpipes && debug=stdout go test -v ./... | tee ../test.log
 
 coverage:
-	cd datapipes && go test -coverprofile=c.out
-	cd datapipes && go tool cover -html=c.out -o coverage.html
-	firefox datapipes/coverage.html
+	cd dpipes && go test -v ./... -coverprofile=c.out
+	cd dpipes && go tool cover -html=c.out -o coverage.html
+	firefox dpipes/coverage.html

--- a/dpipes/common.go
+++ b/dpipes/common.go
@@ -115,7 +115,7 @@ func OpenLogger(where string, ident string) *log.Logger {
 		Handle(err)
 		return log.New(stream, prefix, 0)
 	}
-	panic(errors.New(where+": bad log dest"))
+	panic(errors.New(where + ": bad log dest"))
 }
 
 // MyInfo gets current goroutine info.

--- a/dpipes/execute.go
+++ b/dpipes/execute.go
@@ -102,7 +102,7 @@ func MultiExecuteOn(cmd string) MultiSampleF {
 		}
 		result := make([]Sample, 0, 100)
 		for i := 0; i <= 1000000; i++ {
-			prefix := fmt.Sprintf("%s-" + MultiFmt, "sample", i)
+			prefix := fmt.Sprintf("%s-"+MultiFmt, "sample", i)
 			fnames, err := filepath.Glob(tmpdir + "/" + prefix + ".*")
 			if err != nil || len(fnames) < 1 {
 				// allow gaps in the numbering for the first 100
@@ -128,4 +128,3 @@ func MultiExecuteOn(cmd string) MultiSampleF {
 func MultiProcessSamples(cmd string, ignoreerrs bool) Process {
 	return MultiMapSamples(MultiExecuteOn(cmd), ignoreerrs)
 }
-

--- a/dpipes/go.mod
+++ b/dpipes/go.mod
@@ -2,10 +2,4 @@ module github.com/tmbdev/tarp/dpipes
 
 go 1.14
 
-require (
-	github.com/Masterminds/squirrel v1.2.0
-	github.com/mattn/go-sqlite3 v2.0.3+incompatible
-	github.com/shamaton/msgpack v1.1.1
-	github.com/stretchr/testify v1.2.2
-	gopkg.in/zeromq/goczmq.v4 v4.1.0
-)
+require github.com/stretchr/testify v1.5.1

--- a/dpipes/gopen.go
+++ b/dpipes/gopen.go
@@ -1,12 +1,12 @@
 package dpipes
 
 import (
+	"bytes"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
-	"bytes"
 )
 
 // TODO

--- a/dpipes/messaging/go.mod
+++ b/dpipes/messaging/go.mod
@@ -1,0 +1,12 @@
+module github.com/tmbdev/tarp/dpipes/messaging
+
+replace github.com/tmbdev/tarp/dpipes => ../
+
+go 1.14
+
+require (
+	github.com/shamaton/msgpack v1.1.1
+	github.com/stretchr/testify v1.5.1
+	github.com/tmbdev/tarp/dpipes v0.0.0-00010101000000-000000000000
+	gopkg.in/zeromq/goczmq.v4 v4.1.0
+)

--- a/dpipes/messaging/mpio.go
+++ b/dpipes/messaging/mpio.go
@@ -1,4 +1,4 @@
-package dpipes
+package messaging
 
 import (
 	"errors"
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/shamaton/msgpack"
+	. "github.com/tmbdev/tarp/dpipes"
 	"gopkg.in/zeromq/goczmq.v4"
 )
 

--- a/dpipes/messaging/mpio_test.go
+++ b/dpipes/messaging/mpio_test.go
@@ -1,4 +1,4 @@
-package dpipes
+package messaging
 
 import (
 	"os/exec"
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	. "github.com/tmbdev/tarp/dpipes"
 )
 
 func TestZMQOpen(t *testing.T) {

--- a/dpipes/rawtario.go
+++ b/dpipes/rawtario.go
@@ -2,11 +2,11 @@ package dpipes
 
 import (
 	"archive/tar"
-	"time"
 	"bytes"
 	"fmt"
 	"io"
 	"regexp"
+	"time"
 )
 
 // Raw is a struct representing unaggregated data items (e.g., from a tar file).

--- a/dpipes/sql/go.mod
+++ b/dpipes/sql/go.mod
@@ -1,0 +1,12 @@
+module github.com/tmbdev/tarp/dpipes/sql
+
+replace github.com/tmbdev/tarp/dpipes => ../
+
+go 1.14
+
+require (
+	github.com/Masterminds/squirrel v1.2.0
+	github.com/mattn/go-sqlite3 v2.0.3+incompatible
+	github.com/stretchr/testify v1.5.1
+	github.com/tmbdev/tarp/dpipes v0.0.0-00010101000000-000000000000
+)

--- a/dpipes/sql/sqlite.go
+++ b/dpipes/sql/sqlite.go
@@ -1,4 +1,4 @@
-package dpipes
+package sql
 
 import (
 	"database/sql"
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	sq "github.com/Masterminds/squirrel"
+	. "github.com/tmbdev/tarp/dpipes"
 	// load the sqlite3 driver
 	_ "github.com/mattn/go-sqlite3"
 )

--- a/dpipes/sql/sqlite_test.go
+++ b/dpipes/sql/sqlite_test.go
@@ -1,4 +1,4 @@
-package dpipes
+package sql
 
 import (
 	"database/sql"
@@ -7,6 +7,7 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"
+	. "github.com/tmbdev/tarp/dpipes"
 )
 
 func TestDBSink(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,7 @@ replace github.com/tmbdev/tarp/dpipes => ./dpipes
 go 1.14
 
 require (
-	github.com/bcicen/ctop v0.7.3 // indirect
-	github.com/jessevdk/go-flags v1.4.0
-	github.com/maruel/panicparse v1.3.0 // indirect
-	github.com/tmbdev/tarp/dpipes v0.0.0-20200330012711-53823ac810b9
+	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
+	github.com/stretchr/testify v1.5.1 // indirect
+	github.com/tmbdev/tarp/dpipes v0.0.0-00010101000000-000000000000 // indirect
 )

--- a/tarp/cat.go
+++ b/tarp/cat.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/tmbdev/tarp/dpipes"
+	"github.com/tmbdev/tarp/dpipes/messaging"
 )
 
 var catopts struct {
@@ -27,7 +28,7 @@ func makesource(inputs []string, eof bool) func(dpipes.Pipe) {
 	if zurlre.MatchString(inputs[0]) {
 		Validate(len(inputs) == 1, "can only use a single ZMQ url for input")
 		infolog.Println("# makesource (ZMQ)", inputs[0])
-		return dpipes.ZMQSource(inputs[0], eof)
+		return messaging.ZMQSource(inputs[0], eof)
 	}
 	infolog.Println("# makesource", inputs)
 	return dpipes.TarSources(inputs)
@@ -36,7 +37,7 @@ func makesource(inputs []string, eof bool) func(dpipes.Pipe) {
 func makesink(output string, eof bool) func(dpipes.Pipe) {
 	if zurlre.MatchString(output) {
 		infolog.Println("# makesink (ZMQ)", output)
-		return dpipes.ZMQSink(output, eof)
+		return messaging.ZMQSink(output, eof)
 	}
 	infolog.Println("# makesink ", output)
 	return dpipes.TarSinkFile(output)

--- a/tarp/go.mod
+++ b/tarp/go.mod
@@ -2,9 +2,15 @@ module github.com/tmbdev/tarp/tarp
 
 replace github.com/tmbdev/tarp/dpipes => ../dpipes
 
+replace github.com/tmbdev/tarp/dpipes/messaging => ../dpipes/messaging
+
+replace github.com/tmbdev/tarp/dpipes/sql => ../dpipes/sql
+
 go 1.14
 
 require (
 	github.com/jessevdk/go-flags v1.4.0
-	github.com/tmbdev/tarp/dpipes v0.0.0-20200330014249-228e36f0b803
+	github.com/tmbdev/tarp/dpipes v0.0.0-00010101000000-000000000000
+	github.com/tmbdev/tarp/dpipes/messaging v0.0.0-00010101000000-000000000000
+	github.com/tmbdev/tarp/dpipes/sql v0.0.0-00010101000000-000000000000
 )

--- a/tarp/sort.go
+++ b/tarp/sort.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/tmbdev/tarp/dpipes"
+	dpipesSQL "github.com/tmbdev/tarp/dpipes/sql"
 )
 
 var sortopts struct {
@@ -51,11 +52,11 @@ func sortcmd() {
 	dpipes.Processing(
 		dpipes.TarSources(sortopts.Positional.Inputs),
 		dpipes.SliceSamples(sortopts.Start, sortopts.End),
-		dpipes.DBSink(db, tname, fields),
+		dpipesSQL.DBSink(db, tname, fields),
 	)
 	infolog.Println("reading")
 	dpipes.Processing(
-		dpipes.DBSource(db, tname, fields, sortfields[0]),
+		dpipesSQL.DBSource(db, tname, fields, sortfields[0]),
 		dpipes.CopySamples,
 		dpipes.TarSinkFile(sortopts.Output),
 	)


### PR DESCRIPTION
This packages split enables users to import `dpipes` without having additional, unnecessary dependencies. The most important one, which was moved from `dpipes` to `messaging` is `gopkg.in/zeromq/goczmq.v4` which uses `cgo`. 

I don't insist on this particular split, it's just what I would need. Additionally, please have a look if `go.mod` files are correct in terms of versioning and `replace` statements.