### PR TITLE
Remove the dpipes replace directive

### DIFF
--- a/tarp/go.mod
+++ b/tarp/go.mod
@@ -1,7 +1,5 @@
 module github.com/tmbdev/tarp/tarp
 
-replace github.com/tmbdev/tarp/dpipes => ../dpipes
-
 go 1.17
 
 require (


### PR DESCRIPTION
The `go install` tool complains about the replace directive in `go.mod`:

```console
# go install github.com/webdataset/tarp/tarp@latest
go: downloading github.com/webdataset/tarp v0.0.2
go: downloading github.com/webdataset/tarp/tarp v0.0.0-20221009163818-4aac5677b928
go: github.com/webdataset/tarp/tarp@latest (in github.com/webdataset/tarp/tarp@v0.0.0-20221009163818-4aac5677b928):
	The go.mod file for the module providing named packages contains one or
	more replace directives. It must not contain directives that would cause
	it to be interpreted differently than if it were the main module.
```

After removing the directive the tool compiles and installs successfully. You can try this here: `go install github.com/collabora/tarp/tarp@latest`

Unfortunately the dependency on C libraries `libzmq` and `libsodium` still make it a lot more difficult to install on random machines (in clusters, docker containers etc.) than the old `tarproc` but unfortunately that seems a lot more difficult to fix. :)