### PR TITLE
feat: Add automated Go binary release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,97 @@
+name: Release Go Binaries
+
+on:
+  pull_request:
+    branches:
+      - main
+      - master
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build for ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false # Prevent other jobs from being cancelled if one fails
+      matrix:
+        include:
+          - os: ubuntu-latest
+            goos: linux
+            goarch: amd64
+          - os: macos-latest
+            goos: darwin
+            goarch: arm64
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install C Dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install -y libzmq3-dev libczmq-dev libsodium-dev
+
+      - name: Install C Dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install zeromq czmq libsodium
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'tarp/go.mod'
+          cache: true
+          cache-dependency-path: 'tarp/go.sum'
+
+      - name: Build
+        working-directory: ./tarp # Execute commands within the ./tarp directory
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          go mod tidy
+          
+          echo "Building version: ${RELEASE_VERSION} for ${GOOS}/${GOARCH} on Runner ${{ runner.os }}"
+          go build -v -trimpath \
+            -ldflags="-s -w -X main.version=${RELEASE_VERSION}" \
+            -o ../tarp-${{ matrix.goos }}-${{ matrix.goarch }} \
+            .
+          echo "Built binary: ../tarp-${{ matrix.goos }}-${{ matrix.goarch }}"
+
+      - name: Package Binary
+        run: |
+          ls -l tarp-${{ matrix.goos }}-${{ matrix.goarch }}
+          tar czf tarp-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz tarp-${{ matrix.goos }}-${{ matrix.goarch }}
+          echo "Packaged archive: tarp-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tarp-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: tarp-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
+
+  publish:
+    name: Publish Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: List downloaded files
+        run: find artifacts -type f
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: artifacts/**/*.tar.gz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,15 +53,45 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           RELEASE_VERSION: ${{ github.ref_name }}
+         # --- Static Linking & Compatibility Vars ---
+          CGO_ENABLED: 1 # Ensure Cgo is active for both
+          # Common static linking preference via pkg-config (works for both Linux & macOS if static libs are installed)
+          PKG_CONFIG: "pkg-config --static"
+          # macOS specific deployment target - set ONLY if runner is macOS
+          MACOSX_DEPLOYMENT_TARGET: ${{ runner.os == 'macOS' && '12.0' || '' }} # Sets target for macOS, empty string for Linux
+
         run: |
+          # Optional: Unset empty env vars if they cause issues, though '' is usually fine
+          # if [[ "${{ runner.os }}" != "macOS" && -z "$MACOSX_DEPLOYMENT_TARGET" ]]; then unset MACOSX_DEPLOYMENT_TARGET; fi
+
+          # Verify environment settings
+          echo "Runner OS: ${{ runner.os }}"
+          echo "Target: ${GOOS}/${GOARCH}"
+          echo "PKG_CONFIG: ${PKG_CONFIG}"
+          echo "MACOSX_DEPLOYMENT_TARGET: ${MACOSX_DEPLOYMENT_TARGET}" # Will be empty on Linux
+
           go mod tidy
-          
-          echo "Building version: ${RELEASE_VERSION} for ${GOOS}/${GOARCH} on Runner ${{ runner.os }}"
+          echo "Building version: ${RELEASE_VERSION} (Attempting Static Linking)"
+
           go build -v -trimpath \
             -ldflags="-s -w -X main.version=${RELEASE_VERSION}" \
             -o ../tarp-${{ matrix.goos }}-${{ matrix.goarch }} \
             .
+
           echo "Built binary: ../tarp-${{ matrix.goos }}-${{ matrix.goarch }}"
+
+          # --- Verification Step (OS-Specific) ---
+          echo "Checking dynamic library dependencies:"
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            # Use otool on macOS. Should NOT show libczmq, libzmq, libsodium.
+            otool -L ../tarp-${{ matrix.goos }}-${{ matrix.goarch }} || true
+          elif [[ "${{ runner.os }}" == "Linux" ]]; then
+            # Use ldd on Linux. Should NOT show libczmq, libzmq, libsodium.
+            # It might show Linux standard libs like linux-vdso, libpthread, libc, ld-linux.
+            ldd ../tarp-${{ matrix.goos }}-${{ matrix.goarch }} || true
+          fi
+
+
 
       - name: Package Binary
         run: |

--- a/tarp/go.mod
+++ b/tarp/go.mod
@@ -2,36 +2,37 @@ module github.com/tmbdev/tarp/tarp
 
 replace github.com/tmbdev/tarp/dpipes => ../dpipes
 
-go 1.17
+go 1.23.0
+
+toolchain go1.24.1
 
 require (
-	github.com/dgraph-io/badger/v3 v3.2103.2
-	github.com/jessevdk/go-flags v1.5.0
+	github.com/dgraph-io/badger/v3 v3.2103.5
+	github.com/jessevdk/go-flags v1.6.1
 	github.com/shamaton/msgpack v1.2.1
-	github.com/tmbdev/tarp/dpipes v0.0.0-20220223203531-468ca2eefc90
+	github.com/tmbdev/tarp/dpipes v0.0.0-20221009163818-4aac5677b928
 )
 
 require (
-	github.com/Masterminds/squirrel v1.5.3 // indirect
+	github.com/Masterminds/squirrel v1.5.4 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
-	github.com/cespare/xxhash/v2 v2.1.2 // indirect
-	github.com/dgraph-io/ristretto v0.1.0 // indirect
-	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
-	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgraph-io/ristretto v0.2.0 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/glog v1.0.0 // indirect
-	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/flatbuffers v22.9.29+incompatible // indirect
-	github.com/klauspost/compress v1.15.11 // indirect
+	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
+	github.com/golang/snappy v1.0.0 // indirect
+	github.com/google/flatbuffers v25.2.10+incompatible // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
+	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.15 // indirect
+	github.com/mattn/go-sqlite3 v1.14.27 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	go.opencensus.io v0.23.0 // indirect
-	golang.org/x/net v0.0.0-20221004154528-8021a29435af // indirect
-	golang.org/x/sys v0.0.0-20221006211917-84dc82d7e875 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
+	go.opencensus.io v0.24.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
+	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/zeromq/goczmq.v4 v4.1.0 // indirect
 )


### PR DESCRIPTION
Add GitHub Actions workflow to automate building and publishing Tarp executables for Linux and macOS.

* **Build and Publish Workflow**
  - Create `.github/workflows/release.yaml` to define the build and publish process.
  - Trigger the workflow on push and pull request events to the main branch.
  - Define a build job that runs on both `ubuntu-latest` and `macos-latest` environments.
  - Build Tarp executables for Linux and macOS and upload them as artifacts.
  - Define a publish job that downloads the build artifacts and prepares them for publishing.

* **Go Module Updates** (couldn't make it work with the original version)
  - Update `go.mod` to use Go version 1.23.0 and toolchain version 1.24.1.


## Tests

See example release with artifacts:

- https://github.com/fabito/tarp/releases/tag/v0.0.2
